### PR TITLE
Reflect Reveiw&Feedback

### DIFF
--- a/app/src/main/java/com/example/bbip_clone/ui/CapsuleView.kt
+++ b/app/src/main/java/com/example/bbip_clone/ui/CapsuleView.kt
@@ -335,7 +335,7 @@ fun TimeRing(modifier: Modifier = Modifier, progressRatio: Float) {
             style = Stroke(width = strokeWidth)
         )
         if (progressRatio in 0f..100f) {
-            val progressColor = if (progressRatio == 100f) Gray5 else PrimaryDark
+            val progressColor =PrimaryDark
             drawArc(
                 color = progressColor,
                 startAngle = -90f,

--- a/app/src/main/java/com/example/bbip_clone/ui/CapsuleView.kt
+++ b/app/src/main/java/com/example/bbip_clone/ui/CapsuleView.kt
@@ -261,12 +261,12 @@ fun NoticeBar(
     contentColor: Color = Gray8,
     backgroundColor: Color = Gray2
 ) {
-    Spacer(Modifier.height(12.dp))
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .padding(horizontal = 16.dp)
             .background(backgroundColor, shape = RoundedCornerShape(12.dp))
-            .padding(8.dp),
+            .padding(horizontal = 12.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Box(
@@ -358,9 +358,11 @@ fun BulletinCard(
     Column(
         modifier = modifier
             .size(171.dp, 115.dp)
+            .shadow(16.dp, RoundedCornerShape(12.dp), spotColor = Gray2)
             .background(color = MainWhite, shape = RoundedCornerShape(12.dp))
             .clickable {}
             .padding(13.dp)
+
     ) {
         val borderColor = when {
             data.isNotice && !isStudyHomeScreen -> PrimaryDark
@@ -415,7 +417,8 @@ fun ThisWeekStudyCard(studyWeekData: ThisWeekStudyData) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(start = 17.dp, end = 17.dp)
+            .padding(horizontal = 17.dp)
+            .shadow(16.dp, RoundedCornerShape(12.dp), spotColor = Gray2)
             .background(MainWhite, RoundedCornerShape(12.dp))
             .clickable { }
     ) {
@@ -442,7 +445,7 @@ fun ThisWeekStudyCard(studyWeekData: ThisWeekStudyData) {
                         color = BlackStudyTitle,
                         style = body1_sb16
                     )
-                    Spacer(modifier = Modifier.weight(1f)) // ✅ 여백 추가해서 박스 오른쪽으로 밀기
+                    Spacer(modifier = Modifier.weight(1f))
                     Box(
                         modifier = Modifier
                             .border(width = 1.dp, color = Gray2, shape = RoundedCornerShape(10.dp))

--- a/app/src/main/java/com/example/bbip_clone/ui/UserHomeScreen.kt
+++ b/app/src/main/java/com/example/bbip_clone/ui/UserHomeScreen.kt
@@ -127,10 +127,10 @@ fun UserHomeScreen(navController: NavController) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
             ) {
                 HorizontalDivider()
 
+                Spacer(modifier = Modifier.height((22.dp)))
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -143,7 +143,7 @@ fun UserHomeScreen(navController: NavController) {
                     )
                 }
 
-                Spacer(modifier = Modifier.height(13.dp))
+                Spacer(modifier = Modifier.height(35.dp))
 
                 val isInStudyTime = progressRatio in 0.001f..99.999f
                 Box(
@@ -254,11 +254,11 @@ fun UserHomeScreen(navController: NavController) {
                 LazyRow(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 17.dp),
+                        .padding(start = 17.dp),
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     items(bulletinList) { item ->
-                        BulletinCard(item, true)
+                        BulletinCard(item)
                     }
                 }
                 Spacer(modifier = Modifier.height(23.dp))
@@ -286,7 +286,7 @@ fun UserHomeScreen(navController: NavController) {
                 LazyRow(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 17.dp),
+                        .padding(start = 17.dp),
                 ) {
 
                     items(getUpcomingScheduleData()) { schedule ->
@@ -299,7 +299,7 @@ fun UserHomeScreen(navController: NavController) {
                     painter = painterResource(R.drawable.manual),
                     contentDescription ="manual",
                     modifier = Modifier
-                        .size(359.dp, 79.dp)
+                        .fillMaxSize()
                         .padding(horizontal = 17.dp)
                         .clickable {
                             val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://www.google.com"))

--- a/app/src/main/java/com/example/bbip_clone/ui/UserHomeScreen.kt
+++ b/app/src/main/java/com/example/bbip_clone/ui/UserHomeScreen.kt
@@ -254,13 +254,14 @@ fun UserHomeScreen(navController: NavController) {
                 LazyRow(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(start = 17.dp),
+                        .padding(start = 17.dp, end = 8.dp),
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     items(bulletinList) { item ->
                         BulletinCard(item)
                     }
                 }
+
                 Spacer(modifier = Modifier.height(23.dp))
                 Text(
                     text = weekStudy,

--- a/app/src/main/java/com/example/bbip_clone/ui/UserHomeScreen.kt
+++ b/app/src/main/java/com/example/bbip_clone/ui/UserHomeScreen.kt
@@ -43,6 +43,8 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.example.bbip_clone.R
+import com.example.bbip_clone.convertTodayDate
+import com.example.bbip_clone.model.StudyWeekData
 import com.example.bbip_clone.network.getBulletinBoardData
 import com.example.bbip_clone.network.getNotice
 import com.example.bbip_clone.network.getNotionCheck
@@ -69,6 +71,7 @@ import com.example.bbip_clone.ui.theme.comingTodos
 import com.example.bbip_clone.ui.theme.title4_sb24
 import com.example.bbip_clone.ui.theme.weekStudy
 import kotlinx.coroutines.delay
+import android.util.Log
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
@@ -82,6 +85,19 @@ fun UserHomeScreen(navController: NavController) {
     val todayStudy = studySummaryDataList.firstOrNull { it.isToday }
     val bulletinList = getBulletinBoardData()
     val context = LocalContext.current
+    var studyData by remember { mutableStateOf(emptyList<StudyWeekData>()) }
+    var thisWeekRound by remember { mutableStateOf("") }
+    var studyLastRound by remember { mutableStateOf("") }
+
+    studyData = getStudyWeekData("id")
+    studyData.firstOrNull { it.date > convertTodayDate() }?.let {
+        thisWeekRound = it.round
+    }
+    studyLastRound = studyData.last().round
+    val thisWeekRoundFloat =thisWeekRound.toFloatOrNull() ?: 1f
+    val studyLastRoundFloat =studyLastRound.toFloatOrNull() ?: 1f
+
+
     LaunchedEffect(Unit) {
         noticeCheck = getNotionCheck(true)
         noticeText = getNotice("id")
@@ -134,9 +150,10 @@ fun UserHomeScreen(navController: NavController) {
                     modifier = Modifier.fillMaxWidth(),
                     contentAlignment = Alignment.Center
                 ) {
+                    Log.d("TimeDebug", "start: $thisWeekRoundFloat, last : $studyLastRoundFloat")
                     TimeRing(
                         modifier = Modifier.fillMaxWidth(),
-                        progressRatio = progressRatio
+                        progressRatio = 100-(thisWeekRoundFloat / studyLastRoundFloat * 100)
                     )
 
                     todayStudy?.let { study ->


### PR DESCRIPTION
## Issue
- Closes #51
<br>

## 구현 기능
리뷰 및 피드백 반영
<br>

## 구현 사항


- [ ] column 전체에 padding 되어 있던 오류 수정

- [ ] Timering Logic 수정(진행률 관련)

- [ ] 각 view(bulletinboard 등)에 shadow 추가

- [ ] Lazyrow 우측의 경우 padding을 주지 않고 화면 끝까지 보이도록 수정

- [ ] 최하단 BBIP 이용 가이드 고정 크기 대신 가변 크기로(padding은 고정)

<br>

## 기능 시연
- [ ] 진행률이 현재 스터디 주차 / 총 주차 로 되도록 변경

![Image](https://github.com/user-attachments/assets/19bf2c6f-7862-49d9-86c0-6bbecaf87d15)

- [ ] shadow 추가

![Image](https://github.com/user-attachments/assets/147e9bac-7e47-4666-991c-1c937f72e29f)

- [ ] Lazyrow 우측 패딩 삭제

![Image](https://github.com/user-attachments/assets/abfc85a8-21bb-4ab6-92ba-ed72b0d029fe)

